### PR TITLE
XB8 Modems Only - Add unerrored codewords count

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -197,7 +197,7 @@ def send_to_influx(stats, config):
   current_time = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
 
   for stats_down in stats['downstream']:
-    series.append(Point.from_dict({
+    data = {
       'measurement': 'downstream_statistics',
       'time': current_time,
       'fields': {
@@ -211,7 +211,12 @@ def send_to_influx(stats, config):
         'channel_id': int(stats_down['channel_id']),
         'modulation': stats_down['modulation']
       }
-    }))
+    }
+    ## Only some modems, like the XB8, has the 'unerrored' value
+    if 'unerrored' in stats_down:
+      data['fields']['unerrored'] = int(stats_down['unerrored'])
+
+    series.append(Point.from_dict(data))
 
   for stats_up in stats['upstream']:
     series.append(Point.from_dict({

--- a/src/comcast_xb8_stats.py
+++ b/src/comcast_xb8_stats.py
@@ -119,6 +119,7 @@ def parse_html(html):
      # NOTE: Indexing by channel_id is important as this table might be ordered
      #       differently than the "Channel Bonding" table parsed above.
      channel = stats['downstream'][channel_id]
+     channel['unerrored'] = codeword_rows[1].find_all("td")[i].text.strip()
      channel['corrected'] = codeword_rows[2].find_all("td")[i].text.strip()
      channel['uncorrectables'] = codeword_rows[3].find_all("td")[i].text.strip()
 


### PR DESCRIPTION
## One Line Summary
Add the "unerrored" stat to the to existing "Correctable" and "Uncorrectable" Codewords counts.

## Notes to Reviewer
1. This is based on PR https://github.com/sarabveer/cable-modem-stats/pull/4 so recommend reviewing this one first. 
2. The only new commit in this PR is c8875dd05377724708464ba9dd50373a29dc0257, the other one is for the other branch and Github should see only one comment once the other one is merged.

## Motivation
This is available in the "CM Error Codewords" table and is useful to know what ratio of corrected and errors you are getting to successful codewords.
![image](https://github.com/user-attachments/assets/9147ff54-4cec-47a1-abe6-3ede68c6feef)

## Tested
Test on:
```
Product Type: XB8
HW Version: 2.0
Download Version: Prod_22.2_d31 & Prod_22.2
Model: CGM4981COM
```
![image](https://github.com/user-attachments/assets/4662e542-05b5-46c3-9067-74d985cdb1a9)