### PR TITLE
Fix printing of exception on Influx write error

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -228,11 +228,10 @@ def send_to_influx(stats, config):
       }
     }))
 
-  try:   
+  try:
     write_api.write(bucket = config['influx_bucket'], record = series)
   except Exception:
-    logging.error(Exception)
-    logging.error('Failed To Write To InfluxDB')
+    logging.exception('Failed To Write To InfluxDB')
     return
 
   logging.info('Successfully wrote data to InfluxDB')


### PR DESCRIPTION
## One Line Summary
Corrects printing of the full exception message and stacktrace. Before all that we be printed was "<class 'Exception'>".

## Motivation
When initially setting up it wasn't clear to me what InfluxDb parameters I had wrong.

## Example
### Before
```
2024-08-07 19:09:40,260 INFO     Sending stats to InfluxDB (http://localhost:8086)
2024-08-07 19:09:41,237 ERROR    <class 'Exception'>
2024-08-07 19:09:41,238 ERROR    Failed To Write To InfluxDB
2024-08-07 19:09:41,238 INFO     Sleeping for 120 seconds
```

### After
```
Traceback (most recent call last):
  File "/home/kasten/jkasten2-cable-modem-stats/src/__main__.py", line 232, in send_to_influx
    write_api.write(bucket = config['influx_bucket'], record = series)
  File "/home/kasten/cable-modem-stats/venv/lib/python3.11/site-packages/influxdb_client/client/write_api.py", line 381, in write
    results = list(map(write_payload, payloads.items()))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasten/cable-modem-stats/venv/lib/python3.11/site-packages/influxdb_client/client/write_api.py", line 379, in write_payload
    return self._post_write(_async_req, bucket, org, final_string, payload[0])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasten/cable-modem-stats/venv/lib/python3.11/site-packages/influxdb_client/client/write_api.py", line 516, in _post_write
    return self._write_service.post_write(org=org, bucket=bucket, body=body, precision=precision,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasten/cable-modem-stats/venv/lib/python3.11/site-packages/influxdb_client/service/write_service.py", line 60, in post_write
    (data) = self.post_write_with_http_info(org, bucket, body, **kwargs)  # noqa: E501
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasten/cable-modem-stats/venv/lib/python3.11/site-packages/influxdb_client/service/write_service.py", line 88, in post_write_with_http_info
    self._post_write_prepare(org, bucket, body, **kwargs)  # noqa: E501
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kasten/cable-modem-stats/venv/lib/python3.11/site-packages/influxdb_client/service/write_service.py", line 156, in _post_write_prepare
    raise ValueError("Missing the required parameter `org` when calling `post_write`")  # noqa: E501
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Missing the required parameter `org` when calling `post_write`
2024-08-07 19:16:59,776 INFO     Sleeping for 120 seconds
```

This make the error a little noisily to read, but helps to have the stacktrace to debug, the root of the error is still printed towards the bottom at least.