### PR TITLE
fix: str to int exception with frequency 

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -201,7 +201,7 @@ def send_to_influx(stats, config):
       'measurement': 'downstream_statistics',
       'time': current_time,
       'fields': {
-        'frequency': int(stats_down['frequency']),
+        'frequency': int(float(stats_down['frequency'])),
         'power': float(stats_down['power']),
         'snr': float(stats_down['snr']),
         'corrected': int(stats_down['corrected']),
@@ -223,7 +223,7 @@ def send_to_influx(stats, config):
       'measurement': 'upstream_statistics',
       'time': current_time,
       'fields': {
-        'frequency': int(stats_up['frequency']),
+        'frequency': int(float(stats_up['frequency'])),
         'power': float(stats_up['power']),
         'width': int(stats_up['width']),
       },


### PR DESCRIPTION
When the Internet connection is down on an s33, upstream frequency is returned as the string ' 0.0'.   This causes a ValueError exception when you try int(' 0.0'), and values are not written to the DB. The decimal part seems to be the issue. The way around this is to first cast the string to a float type, then cast the float to an int. This is safe for any number like string, with or without a decimal place.

<code>
In [33]: int(' 0.0')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[33], line 1
----> 1 int(' 0.0')

ValueError: invalid literal for int() with base 10: ' 0.0'

In [34]: int(float(' 0.0'))
Out[34]: 0

In [35]: int(float('0.0'))
Out[35]: 0

In [36]: int(float('238939873'))
Out[36]: 238939873
</code>