### PR TITLE
Fix crash when reading unrecognized downstream modulation

### DIFF
--- a/src/comcast_xb8_stats.py
+++ b/src/comcast_xb8_stats.py
@@ -100,6 +100,8 @@ def parse_html(html):
       channel['modulation'] = "OFDM PLC"
     elif modulation == "256 QAM":
       channel['modulation'] = "QAM256"
+    else:
+      channel['modulation'] = modulation
 
     frequency = downstream_rows[2].find_all("td")[i].text.strip()
     if "MHz" in frequency:


### PR DESCRIPTION
If the line is having issues, and some DOCSIS channels aren't locking, the Modulation field in the UI will show "Unknown" instead of the usual values, which crashes the script.

This seems to already be handled properly for Upstream values, so just Downstream needed to be fixed.